### PR TITLE
Change directory into the package dir when running hooks

### DIFF
--- a/lua/dep.lua
+++ b/lua/dep.lua
@@ -248,6 +248,8 @@ local function run_hooks(package, type)
   for i = 1, #hooks do
     local ok, err = pcall(hooks[i])
     if not ok then
+      vim.fn.chdir(last_cwd)
+
       package.error = true
       return false, err
     end

--- a/lua/dep.lua
+++ b/lua/dep.lua
@@ -240,6 +240,11 @@ local function run_hooks(package, type)
 
   local start = os.clock()
 
+  -- chdir into the package directory to make running external commands
+  -- from hooks easier.
+  local last_cwd = vim.fn.getcwd()
+  vim.fn.chdir(package.dir)
+
   for i = 1, #hooks do
     local ok, err = pcall(hooks[i])
     if not ok then
@@ -248,6 +253,7 @@ local function run_hooks(package, type)
     end
   end
 
+  vim.fn.chdir(last_cwd)
   package.perf[type] = os.clock() - start
 
   logger:log(


### PR DESCRIPTION
Resolves #1 

This makes running external commands like `make` from hooks easier to do.