### PR TITLE
Fixed logger file read error on first run

### DIFF
--- a/lua/dep/log.lua
+++ b/lua/dep/log.lua
@@ -3,6 +3,12 @@ local logger = {
   silent = false,
 }
 
+local basepath = vim.fn.stdpath("cache")
+local dirExists = vim.loop.fs_stat(basepath)
+if dirExists == nil then
+  vim.loop.fs_mkdir(basepath, 0x1FF) -- 0777
+end
+
 local colors = {
   skip = "Comment",
   clean = "Boolean",
@@ -16,7 +22,7 @@ function logger:open(path)
   self:close()
 
   self.path = path or self.path
-  self.handle = vim.loop.fs_open(self.path, "w", 0x1A4) -- 0644
+  self.handle = assert(vim.loop.fs_open(self.path, "w", 0x1A4)) -- 0644
   self.pipe = vim.loop.new_pipe()
 
   self.pipe:open(self.handle)


### PR DESCRIPTION
Following the instructions on a clean install of neovim, it failed on first run since `~/.config/nvim/` didn't exist.
I added an init block to the logger so it would create this directory if it doesn't exist.
I also made logger open function more verbose if it fails to open `dep.log` file

Note, even if you would rather this plugin not auto-create the directory, I think having an `assert` (or maybe some error logging) on the file open would still be good so users can see why it failed.